### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,6 @@ has the sha1 hash of `filehash`. Returns 200 on success.
 Returns the list of all filenames currently being housed. If json is `0` (or ommitted) the list is
 simply newline separated, otherwise it comes in the form of a json list.
 
-`GET /allattributes`
-
-Returns a json-map. Each key is a filename, each value is another hash of all the attributes marlin
-has in redis about a the file (size, hash, etc...).
-
 `GET /<filename>`
 
 Returns the contents of `filename`, or 404 if it doesn't exist.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ simply newline separated, otherwise it comes in the form of a json list.
 
 Returns the contents of `filename`, or 404 if it doesn't exist.
 
-`GET /<filename>/all`
+`GET /<filename>/all?json=[0|1]`
 
-Returns a json-map of all the attributes marlin has in redis about `filename`, or 404 if it doesn't
-exists.
+Returns a map of all the attributes marlin has in redis about `filename`, or 404 if it doesn't
+exists. If `json` is not set the map is returned as a newline separated list of `key value` lines.
 
 `GET /<filename>/<attribute>`
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
-* proper logging formatting
 * /all needs a trailing newline
 * try to get rid of application/octet-stream nonsense
 * fix delayed delete
-* If root doesn't exist or permissions are denied or something there is no error

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-* try to get rid of application/octet-stream nonsense

--- a/TODO
+++ b/TODO
@@ -1,2 +1,1 @@
 * try to get rid of application/octet-stream nonsense
-* fix delayed delete

--- a/TODO
+++ b/TODO
@@ -1,3 +1,2 @@
-* /all needs a trailing newline
 * try to get rid of application/octet-stream nonsense
 * fix delayed delete

--- a/src/marlin/core.clj
+++ b/src/marlin/core.clj
@@ -21,9 +21,8 @@
   (db/init)
   (fs/init)
 
-  (let [file-root (java.io.File. (config/cget :root))]
-    (when-not (or (.exists file-root) (.mkdirs file-root))
-      (log/warn (str "Could not create root file directory: " (config/cget :root) ", probably because of lack of permissions"))))
+  (when-not (fs/mkdirs (config/cget :root))
+    (log/warn (str "Could not create root file directory: " (config/cget :root) ", probably because of lack of permissions")))
 
   (when (config/cget :sync-on-start)
     (log/info "Wiping database and synchronizing it with the filesystem")

--- a/src/marlin/core.clj
+++ b/src/marlin/core.clj
@@ -5,7 +5,8 @@
   (:require [marlin.handler :as handler]
             [marlin.config  :as config]
             [marlin.db      :as db]
-            [marlin.fs      :as fs]))
+            [marlin.fs      :as fs]
+            [marlin.log     :as log]))
 
 (def description
   "A simple REST api for interacting with a file system, using redis as a backend")
@@ -22,10 +23,10 @@
 
   (let [file-root (java.io.File. (config/cget :root))]
     (when-not (or (.exists file-root) (.mkdirs file-root))
-      (println "Could not create root file directory:" (config/cget :root) ", probably because of lack of permissions")))
+      (log/warn (str "Could not create root file directory: " (config/cget :root) ", probably because of lack of permissions"))))
 
   (when (config/cget :sync-on-start)
-    (println "Wiping database and synchronizing it with the filesystem")
+    (log/info "Wiping database and synchronizing it with the filesystem")
     (handler/sync-db-with-fs)))
 
 

--- a/src/marlin/fs.clj
+++ b/src/marlin/fs.clj
@@ -90,3 +90,10 @@
                        (map #(.getName %))
                        )]
     (doseq [filename filenames] (fun filename))))
+
+(defn mkdirs
+  "Does the equivalent of mkdir -p on linux. Returns true if the directory was successfully created
+  or already existed, false otherwise"
+  [dir]
+  (let [dirf (java.io.File. dir)]
+    (or (.exists dirf) (.mkdirs dirf))))

--- a/src/marlin/handler.clj
+++ b/src/marlin/handler.clj
@@ -75,7 +75,7 @@
     (let [all (db/get-all-files)]
       (if (and json (not (= json "0")))
         (json-200 all)
-        (text-200 (apply str (interpose \newline all))))))
+        (text-200 (str (apply str (interpose \newline all)) \newline)))))
 
   (GET "/sync" {}
     (future (sync-db-with-fs))

--- a/src/marlin/handler.clj
+++ b/src/marlin/handler.clj
@@ -77,11 +77,6 @@
         (json-200 all)
         (text-200 (apply str (interpose \newline all))))))
 
-  ;; TODO this is not atomic, might be better to just take it out
-  (GET "/allattributes" {}
-    (json-200
-      (reduce #(assoc %1 %2 (db/get-all-file-attributes %2)) {} (db/get-all-files))))
-
   (GET "/sync" {}
     (future (sync-db-with-fs))
     {:status 200})

--- a/src/marlin/handler.clj
+++ b/src/marlin/handler.clj
@@ -47,7 +47,10 @@
       (set-all-attributes % fsize fhash))))
 
 (defroutes app-routes
-  (GET "/" [] "Some info would probably go here")
+  (GET "/" [] "
+    Marlin is a REST api which sits on top of a filesystem, making it easy to
+    put and delete files and to get information about those files. See
+    https://github.com/cryptic-io/marlin for the source/docs\n")
 
   (PUT "/:fn" {{ filename :fn filehash :hash } :params body :body { content-type "content-type" } :headers}
     (log/info (str "PUT " filename " " filehash " initiated"))

--- a/src/marlin/handler.clj
+++ b/src/marlin/handler.clj
@@ -108,13 +108,16 @@
       (text-200 value)))
 
   (DELETE "/:fn" {{ filename :fn delay-amnt :delay } :params}
-    (log/info (str "DELETE " filename " in " delay-amnt " milliseconds"))
-    (let [dodel (fn [] (.delete (java.io.File. (fs/full-name filename)))
+    (let [dodel (fn [] (log/info (str "DELETE " filename))
+                       (.delete (java.io.File. (fs/full-name filename)))
                        (db/del-file filename)
                        (db/unlock-file filename)
                        {:status 200}) ]
       (if-not (nil? delay-amnt)
-        (do (at (+ (now) (Integer/valueOf delay-amnt)) dodel at-pool) {:status 200})
+        (let [delay-int (Integer/valueOf delay-amnt)]
+          (do (log/info (str "DELETE " filename " in " delay-int " milliseconds"))
+              (at (+ (now) delay-int) dodel at-pool)
+              {:status 200}))
         (dodel))))
 
   (route/resources "/")

--- a/src/marlin/handler.clj
+++ b/src/marlin/handler.clj
@@ -64,7 +64,7 @@
         ;If we can then try to put the file
         (let [path (fs/full-path filename)
               fullname (fs/path-join path filename)]
-          (if-not (.mkdirs (java.io.File. path))
+          (if-not (fs/mkdirs path)
             (do (log/warn (str "PUT " filename " - Could not create directory: " path))
                 (db/unlock-file filename)
                 {:status 500 :body "Could not create internal directory"})

--- a/src/marlin/log.clj
+++ b/src/marlin/log.clj
@@ -1,0 +1,6 @@
+(ns marlin.log)
+  ;(:import org.eclipse.jetty.util.log.Log))
+
+(def debug (partial println "DEBUG"))
+(def info  (partial println "INFO"))
+(def warn  (partial println "WARN"))


### PR DESCRIPTION
The following fixes have been implemented:
- If marlin doesn't have permission to create a directory an error is now thrown to the console
- `/all` now has a trailing newline

The following changes have been made:
- More logging on all (`PUT` and `DELETE`) rest methods that alter the state of the filesystem
- Took out `/allattributes`, as it wasn't an atomic operation
- `/:fn/all`'s default mode is to return plaintext instead of json
